### PR TITLE
Mikal sprint 4 bugs

### DIFF
--- a/Functions/GetDeleteLanguage.cs
+++ b/Functions/GetDeleteLanguage.cs
@@ -94,8 +94,15 @@ namespace Functions
                 return (ActionResult)new StatusCodeResult(404);
             }
 
-            // No resource found with that language
-            if (oBook.Pages.Find(y=>y.Number.Contains(pageid)).Languages.Find(z => z.language.Contains(languagecode)) == null)
+            //check if languages are null
+            Page page = oBook.Pages.Find(y => y.Number.Contains(pageid));
+            if (page != null && page.Languages[0] == null)
+            {
+                return (ActionResult)new StatusCodeResult(404);
+            }
+
+                // No resource found with that language if language array isnt null
+                if (oBook.Pages.Find(y=>y.Number.Contains(pageid)).Languages.Find(z => z.language.Contains(languagecode)) == null)
             {
                 return (ActionResult)new StatusCodeResult(404);
             }

--- a/Functions/Language.cs
+++ b/Functions/Language.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Functions
 {
-    [JsonObject]
+    [JsonObject] 
     class Language
     {
         [JsonProperty(PropertyName = "language")]

--- a/Functions/PagesAndLanguages.cs
+++ b/Functions/PagesAndLanguages.cs
@@ -19,7 +19,7 @@ namespace Functions
 {
     public static class PagesAndLanguages
     {
-        [FunctionName("PagesAndLanguages")]
+        [FunctionName("PostPutPagesAndLanguages")]
         [Consumes("application/json")]
         [Produces("application/json")]
         public static async Task<IActionResult> Run(
@@ -237,7 +237,7 @@ namespace Functions
         {
             bool valid = false;
             if (data?.title != null && data?.description != null && data?.author != null
-                && data?.cover_image != null && data?.pages != null)
+                 && data?.pages != null)
             {
                 valid = true;
             }

--- a/Functions/PostPage.cs
+++ b/Functions/PostPage.cs
@@ -101,13 +101,39 @@ namespace Functions
             }
             else
             {
+                int length;
                 //get the page array length
-                int length = books[0].Pages.Count;
-                //create a new page with length +1
-                Page page = new Page();
-                length += 1;
-                page.Number = length.ToString();
-                books[0].Pages.Add(page);
+                if (books[0].Pages != null)
+                {
+                     length = books[0].Pages.Count;
+                    if (books[0].Pages[0] != null)
+                    {
+
+
+                        //create a new page with length +1
+                        Page page = new Page();
+                        length += 1;
+                        page.Number = length.ToString();
+                        books[0].Pages.Add(page);
+                    }
+                    else
+                    {
+                        List<Page> pages = new List<Page>();
+                        Page page = new Page();
+                        page.Number = "1";
+                        pages.Add(page);
+                        books[0].Pages = pages;
+                        length = 1;
+                    }
+                }
+                else {
+                    List<Page> pages = new List<Page>();
+                    Page page = new Page();
+                    page.Number = "1";
+                    pages.Add(page);
+                    books[0].Pages = pages;
+                    length = 1;
+                }
                 //update document in db if route variables and returned book matches
                 await client.UpsertDocumentAsync(UriFactory.CreateDocumentCollectionUri(database, collection), books[0]);
                 //return page number 

--- a/Functions/PutPages.cs
+++ b/Functions/PutPages.cs
@@ -187,7 +187,7 @@ namespace Functions
         {
             bool valid = false;
             if (data?.title != null && data?.description != null && data?.author != null
-                && data?.cover_image != null && data?.pages != null)
+                && data?.pages != null)
             {
                 valid = true;
             }


### PR DESCRIPTION
fixing bug when book isnt created with a page object set to null.  more than half of the books in the db dont have a page object.  for example -

{
    "id": "6ce5dcb2-7b9d-4017-96dc-e9f75735697b",
    "description": "The second book in the series about the battle for Middle Earth.",
    "author": "JRR Tolkien",
    "title": "The Two Towers",
    "_rid": "QO9LAPsfmOM1AAAAAAAAAA==",
    "_self": "dbs/QO9LAA==/colls/QO9LAPsfmOM=/docs/QO9LAPsfmOM1AAAAAAAAAA==/",
    "_etag": "\"390021f5-0000-0000-0000-5c7e0f710000\"",
    "_attachments": "attachments/",
    "_ts": 1551765361
}

this was causing a 500 error when trying to post a page.  a book should be instantiated with a page object set to null like this one

{
    "id": "f7603c88-278c-4211-bfc8-549644172954",
    "description": "This thought-provoking French children's book teaches lessons about life and human nature.",
    "author": " Antoine de Saint-Exupery",
    "cover_image": null,
    "title": "The Little Prince",
    "pages": null,
    "_rid": "QO9LAPsfmOM-AAAAAAAAAA==",
    "_self": "dbs/QO9LAA==/colls/QO9LAPsfmOM=/docs/QO9LAPsfmOM-AAAAAAAAAA==/",
    "_etag": "\"00004897-0000-0000-0000-5c8410c40000\"",
    "_attachments": "attachments/",
    "_ts": 1552158916
}

 but this should fix it in case this continues to happen.

Tested an deployed to my one box.